### PR TITLE
changed file storage root location and custom root sitemap name

### DIFF
--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -20,6 +20,8 @@ SYSTEM_GZIP_PATH = getattr(settings, 'STATICSITEMAPS_SYSTEM_GZIP_PATH', '/usr/bi
 FILENAME_TEMPLATE = getattr(settings,
                             'STATICSITEMAPS_FILENAME_TEMPLATE',
                             'sitemap-%(section)s-%(page)s.xml')
+# Sitemap name can be different than sitemap.xml so making it customizable.
+ROOT_SITEMAP_NAME = getattr(settings, 'STATICSITEMAPS_ROOT_SITEMAP_NAME', 'sitemap.xml')
 
 # Only for backwards compatibility, same as URL.
 DOMAIN = getattr(settings, 'STATICSITEMAPS_DOMAIN', None)

--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -27,10 +27,11 @@ __author__ = 'xaralis'
 
 
 class SitemapGenerator(object):
+
     def __init__(self, verbosity):
         self.verbosity = verbosity
         self.has_changes = False
-        self.storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
+        self.storage = _lazy_load(conf.STORAGE_CLASS)(location='/')
         self.sitemaps = _lazy_load(conf.ROOT_SITEMAP)
 
         if not isinstance(self.sitemaps, dict):
@@ -97,7 +98,7 @@ class SitemapGenerator(object):
                     'lastmod': lastmod
                 })
 
-        path = os.path.join(conf.ROOT_DIR, 'sitemap.xml')
+        path = os.path.join(conf.ROOT_DIR, conf.ROOT_SITEMAP_NAME)
         self.out('Writing index file.', 2)
 
         if self.storage.exists(path):
@@ -127,7 +128,8 @@ class SitemapGenerator(object):
 
         if conf.MOCK_SITE:
             if conf.MOCK_SITE_NAME is None:
-                raise ImproperlyConfigured("STATICSITEMAPS_MOCK_SITE_NAME must not be None. Try setting to www.yoursite.com")
+                raise ImproperlyConfigured(
+                    "STATICSITEMAPS_MOCK_SITE_NAME must not be None. Try setting to www.yoursite.com")
             from django.contrib.sites.requests import RequestSite
             from django.test.client import RequestFactory
             rs = RequestSite(RequestFactory().get('/', SERVER_NAME=conf.MOCK_SITE_NAME))


### PR DESCRIPTION
what ?
 + customizable root sitemap name.
 + changed the storage location to `/` cause the files are stored like  `sitemaps/sitemaps/sitemap.xml`
when sitemaps is given as ROOT_DIR .if we are using S3 as storage. when it was not doing what it supposed to do.